### PR TITLE
New digest

### DIFF
--- a/src/identifierinterval.ts
+++ b/src/identifierinterval.ts
@@ -81,6 +81,12 @@ export class IdentifierInterval {
         return this.getBaseId(this.end)
     }
 
+    digest (): number {
+        // '| 0' converts to 32bits integer
+        const baseDigest = this.base.reduce((prev, v) => (prev * 17 + v) | 0, 0)
+        return ((this.begin * 17 + this.end) * 17 + baseDigest) | 0
+    }
+
     toString (): string {
         return 'Id[' + this.base.join(",") + ', ' +
                 this.begin + ' .. ' + this.end + ']'

--- a/src/logootsropes.ts
+++ b/src/logootsropes.ts
@@ -744,19 +744,18 @@ export class LogootSRopes {
         }
     }
 
+    /**
+     * @return tree digest
+     */
     digest (): number {
-        let result
+        let result = 0
         const root = this.root
         if (root !== null) {
-            const linearRpr = (root.toString() + "\n")
-                .replace(/\t+|(?:#\n)/g, "") + "\n"
-            result = 11
-            for (let i = 0; i < linearRpr.length; i++) {
-                result = (31 * result) + linearRpr.charCodeAt(i)
-                result = result | 0 // Convert to 32bits integer
+            const linearRpr = root.toList()
+            for (let idi of linearRpr) {
+                result = (result * 17 + idi.digest()) | 0
+                    // Convert to 32bits integer
             }
-        }  else {
-            result = 0
         }
         return result
     }

--- a/src/ropesnodes.ts
+++ b/src/ropesnodes.ts
@@ -286,6 +286,17 @@ export class RopesNodes {
                 leftToString.replace(/(\t+)/g, "\t$1")
     }
 
+    /**
+     * @return linear representation
+     */
+    toList (): IdentifierInterval[] {
+        const idi = new IdentifierInterval(this.block.id.base,
+            this.offset, this.maxOffset())
+        const leftList =  (this.left !== null) ? this.left.toList() : []
+        const rightList = (this.right !== null) ? this.right.toList() : []
+        return leftList.concat(idi, rightList)
+    }
+
     getIdentifierInterval (): IdentifierInterval {
         return new IdentifierInterval(this.block.id.base,
             this.offset, this.maxOffset())

--- a/test/ropesnodes.test.ts
+++ b/test/ropesnodes.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Victorien Elvinger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import test from "ava"
+import {IdentifierInterval} from "../src/identifierinterval.js"
+import {LogootSBlock} from "../src/logootsblock.js"
+import {RopesNodes} from "../src/ropesnodes.js"
+
+test("matching-linear-representation", (t) => {
+    const idi1 = new IdentifierInterval([200, 3], 0, 5)
+    const idi2 = new IdentifierInterval([300, 3], 0, 5)
+    const idi3 = new IdentifierInterval([300, 4, 2], 0, 5)
+    const block1 = new LogootSBlock(idi1, 5)
+    const block2 = new LogootSBlock(idi2, 5)
+    const block3 = new LogootSBlock(idi3, 5)
+    const tree1 = new RopesNodes(block2, 0, 5,
+        RopesNodes.leaf(block1, 0, 5),
+        RopesNodes.leaf(block3, 0, 5))
+    const tree2 = new RopesNodes(block1, 0, 5, null,
+        new RopesNodes(block2, 0, 5, null,
+             RopesNodes.leaf(block3, 0, 5)))
+    const tree3 = new RopesNodes(block3, 0, 5,
+         new RopesNodes(block2, 0, 5,
+             RopesNodes.leaf(block1, 0, 5), null), null)
+    const tree4 = new RopesNodes(block3, 0, 5,
+        new RopesNodes(block1, 0, 5, null,
+            RopesNodes.leaf(block2, 0, 5)), null)
+    const tree5 = new RopesNodes(block1, 0, 5, null,
+        new RopesNodes(block3, 0, 5,
+            RopesNodes.leaf(block2, 0, 5), null))
+    const list1 = tree1.toList()
+    const list2 = tree2.toList()
+    const list3 = tree3.toList()
+    const list4 = tree4.toList()
+    const list5 = tree5.toList()
+
+    t.deepEqual(list2, list1)
+    t.deepEqual(list3, list1)
+    t.deepEqual(list4, list1)
+    t.deepEqual(list5, list1)
+})


### PR DESCRIPTION
Hi!

Current version of LogootSRopes#digest in production relies on RopesNodes#toString.

RopesNodes#toString is only for debugging purpose and does not offer any guarantee about its output.

The proposed version of LogootSRopes#digest relies on RopesNodes#toList.
RopesNodes#toList outputs a linear representation of a the tree such that two distinct trees with the same items have the same linear representation.

NOTE: the new implementation needs to be tested. Only RopesNodes#toList has a unit test.