### PR TITLE
Enable the use of MIN as regular offset

### DIFF
--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -38,6 +38,10 @@ export class Identifier {
 // Creation
     constructor (tuples: IdentifierTuple[]) {
         console.assert(tuples.length > 0, "tuples must not be empty")
+        // Last random must be different of INT_32_MIN_VALUE
+        // This ensures a dense set.
+        const lastRandom = tuples[tuples.length - 1].random
+        console.assert(lastRandom > INT_32_MIN_VALUE)
 
         this.tuples = tuples
     }
@@ -58,7 +62,7 @@ export class Identifier {
                     }
                     i++
                 }
-                if (isOk) {
+                if (isOk && tuples[tuples.length - 1].random > INT_32_MIN_VALUE) {
                     return new Identifier(tuples)
                 }
             }
@@ -75,7 +79,7 @@ export class Identifier {
      */
     static generateWithSameBase (id: Identifier, offset: number): Identifier {
         console.assert(Number.isSafeInteger(offset), "offset must be a safe integer")
-        console.assert(offset > INT_32_MIN_VALUE && offset <= INT_32_MAX_VALUE, "offset ∈ ]INT_32_MIN_VALUE, INT_32_MAX_VALUE]")
+        console.assert(offset >= INT_32_MIN_VALUE && offset <= INT_32_MAX_VALUE, "offset ∈ ]INT_32_MIN_VALUE, INT_32_MAX_VALUE]")
 
         const tuples: IdentifierTuple[] = id.tuples.map((tuple: IdentifierTuple, i: number) => {
             if (i === id.length - 1) {
@@ -282,7 +286,7 @@ export class Identifier {
         console.assert(length > 0, "length must be superior to 0 ")
 
         // Prevent an underflow when computing lastOffset - length
-        return this.lastOffset > INT_32_MIN_VALUE + length
+        return this.lastOffset >= INT_32_MIN_VALUE + length
     }
 
     /**

--- a/src/identifiertuple.ts
+++ b/src/identifiertuple.ts
@@ -30,12 +30,10 @@ export class IdentifierTuple {
     readonly offset: number
 
     constructor (random: number, replicaNumber: number, clock: number, offset: number) {
-        [random, replicaNumber, clock].forEach((value) => {
+        [random, replicaNumber, clock, offset].forEach((value) => {
             console.assert(Number.isSafeInteger(value), "Each value must be a safe integer")
             console.assert(value >= INT_32_MIN_VALUE && value <= INT_32_MAX_VALUE, "Each value ∈ [INT_32_MIN_VALUE, INT_32_MAX_VALUE]")
         })
-        console.assert(Number.isSafeInteger(offset), "offset must be a safe integer")
-        console.assert(offset > INT_32_MIN_VALUE && offset <= INT_32_MAX_VALUE, "offset ∈ ]INT_32_MIN_VALUE, INT_32_MAX_VALUE]")
 
         this.random = random
         this.replicaNumber = replicaNumber
@@ -52,7 +50,7 @@ export class IdentifierTuple {
             typeof o.clock === "number" && Number.isSafeInteger(o.clock) &&
             INT_32_MIN_VALUE <= o.clock && o.clock <= INT_32_MAX_VALUE &&
             typeof o.offset === "number" && Number.isSafeInteger(o.offset) &&
-            INT_32_MIN_VALUE < o.clock && o.clock <= INT_32_MAX_VALUE) {
+            INT_32_MIN_VALUE <= o.offset && o.offset <= INT_32_MAX_VALUE) {
 
             return new IdentifierTuple(o.random, o.replicaNumber, o.clock, o.offset)
         }
@@ -68,7 +66,8 @@ export class IdentifierTuple {
      */
     static generateWithSameBase (tuple: IdentifierTuple, offset: number): IdentifierTuple {
         console.assert(Number.isSafeInteger(offset), "offset must be a safe integer")
-        console.assert(offset > INT_32_MIN_VALUE && offset <= INT_32_MAX_VALUE, "offset ∈ ]INT_32_MIN_VALUE, INT_32_MAX_VALUE]")
+        console.assert(offset >= INT_32_MIN_VALUE && offset <= INT_32_MAX_VALUE,
+            "offset ∈ ]INT_32_MIN_VALUE, INT_32_MAX_VALUE]")
 
         return new IdentifierTuple(tuple.random, tuple.replicaNumber, tuple.clock, offset)
     }

--- a/test/identifier.test.ts
+++ b/test/identifier.test.ts
@@ -145,7 +145,7 @@ test("hasPlaceAfter-max-last", (t) => {
 })
 
 test("hasPlaceBefore-min-last", (t) => {
-    const tuple: IdentifierTuple = new IdentifierTuple(1, 0, 0, INT_32_MIN_VALUE + 2)
+    const tuple: IdentifierTuple = new IdentifierTuple(1, 0, 0, INT_32_MIN_VALUE + 1)
     const id = new Identifier([tuple])
 
     t.true(id.hasPlaceBefore(1))


### PR DESCRIPTION
An identifier is a list of quadruples <random,_,_,offset>.
The set of identifiers have to be dense such that an identifier
 can always be generated between two identifiers. To ensure this,
 the component 'random' of the last tuple is different of MIN.

[<MIN,_,_,_>,<MIN+1,_,_,_>] is a valid dientifier
[<MIN,_,_,_>,<MIN,_,_,_>] is an invalid identifier

In the old version of identifiers (without tuples), we excluded
 MIN for every component (including offset). This constraint is
 no longer useful and could even disrupt the well-understanding
 of the algoruthm.

We add MIN as a regular value of the offset component.